### PR TITLE
Locked screen orientation

### DIFF
--- a/ddr/ddr/Info.plist
+++ b/ddr/ddr/Info.plist
@@ -37,8 +37,6 @@
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>

--- a/ddr/ddr/Info.plist
+++ b/ddr/ddr/Info.plist
@@ -33,12 +33,10 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Locked the screen rotation in the proper position (for both ipads and iphones - note that the plist properties are separate)