### PR TITLE
fixed vanishing bats during training

### DIFF
--- a/ddr/ddr/Models/GameEntities/Oncomer.swift
+++ b/ddr/ddr/Models/GameEntities/Oncomer.swift
@@ -40,6 +40,15 @@ class Oncomer: SKSpriteNode, Spawnable {
       xScale =  zProgress
       yScale = xScale
       
+      // and hide iff they have passed 0
+      // Note: this makes HideEffect obselete
+      if (zPosition < 0) {
+        self.isHidden = true
+      }
+      else {
+        self.isHidden = false
+      }
+      
       // update visual - screen position
       // oncomers move from vanishing pt in middle of screen
       // and progress to either edge of screen or the middle


### PR DESCRIPTION
Bats now vanish in training levels. In fact, all oncomers will be visible if and only if they have a non-negative z position. This makes hide effects obsolete and they should be removed in a future change, but right now they are not hurting anything and removing them may be a little tedious. This does not solve the core issue of the update loop not functioning perfectly in training levels, which should be revisited in the future.